### PR TITLE
Корректное имя таблицы если таблица указана как {{%tableName}}

### DIFF
--- a/controllers/ExportController.php
+++ b/controllers/ExportController.php
@@ -299,7 +299,7 @@ class ExportController extends Controller
         $queryParams = Json::decode(\Yii::$app->request->post('queryParams'));
         $searchModel = \Yii::$app->request->post('model');
         $searchModel = new $searchModel;
-        $tableName = $searchModel->tableName();
+        $tableName = $searchModel->getTableSchema()->fullName;
         $dataProvider = $searchModel->search($queryParams);
         $title = \Yii::$app->request->post('title');
         $getAll = \Yii::$app->request->post('getAll');


### PR DESCRIPTION
Если таблица указана как {{%tableName}}
`$tableName = $searchModel->tableName();`
вернет '{{%tableName}}'
Если заменить на
`$tableName = $searchModel->getTableSchema()->fullName;`
вернет 'prefix_tableName'